### PR TITLE
PLT-1800 Set client Accept-Language in default headers

### DIFF
--- a/client.jsx
+++ b/client.jsx
@@ -31,6 +31,10 @@ export default class Client {
         this.url = url;
     }
 
+    setAcceptLanguage(locale) {
+        this.defaultHeaders['Accept-Language'] = locale;
+    }
+
     setTeamId(id) {
         this.teamId = id;
     }


### PR DESCRIPTION
This add the ability to set `Accept-Language Header` for every request. Needed for getting localize messages from the server